### PR TITLE
Fix CSV export for devices for which timezone is not set

### DIFF
--- a/wattwatchers_rest_api_v3_long_energy.ipynb
+++ b/wattwatchers_rest_api_v3_long_energy.ipynb
@@ -478,16 +478,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "long_energy"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "xjVMflQXVloh"
@@ -635,7 +625,7 @@
     "  with open(f'/gdrive/My Drive/{file_name}.csv', 'w', newline='') as f:\n",
     "    writer = csv.DictWriter(f, headers)\n",
     "    writer.writeheader()\n",
-    "\n",
+    "    \n",
     "    for device in data:\n",
     "      device_id = device['id']\n",
     "      for item in device['data']:\n",
@@ -649,6 +639,9 @@
     "  \n",
     "  def _device_row_from_device_data(data: dict):\n",
     "    metadata = data['metadata']\n",
+    "    if not 'timezone'in metadata:\n",
+    "      metadata['timezone'] = ''\n",
+    "        \n",
     "    row = {'device_id': metadata['id'], 'timezone': metadata['timezone'], 'phases_count': metadata['phases']['count']}\n",
     "    for idx, channel_data in enumerate(metadata['channels']):\n",
     "      for key, value in channel_data.items():\n",
@@ -661,7 +654,7 @@
     "  with open(f'/gdrive/My Drive/{file_name}.csv', 'w', newline='') as f:\n",
     "    writer = csv.DictWriter(f, headers)\n",
     "    writer.writeheader()\n",
-    "\n",
+    "    \n",
     "    for device in data:\n",
     "      row = _device_row_from_device_data(device)\n",
     "      writer.writerow(row)\n",
@@ -696,7 +689,7 @@
    "source": [
     "# Save the downloaded data to file, \n",
     "# based on the values defined in the configuration code block at the start of the notebook.\n",
-    "save_data(long_energy)\n"
+    "save_data(long_energy)"
    ]
   }
  ],


### PR DESCRIPTION
This PR fixes a bug where the script would crash when trying to export data to CSV for a device for which the timezone is not set. Now setting the timezone to an empty string in that case.